### PR TITLE
feat: Display emoji flags in language selector

### DIFF
--- a/src/components/ui/LanguageSelector.tsx
+++ b/src/components/ui/LanguageSelector.tsx
@@ -37,19 +37,21 @@ interface Language {
 const languages: Language[] = [
   { code: 'en', name: 'English', flag: '🇬🇧' },
   { code: 'es', name: 'Español', flag: '🇪🇸' },
-  // { code: 'fr', name: 'Français', flag: '🇫🇷' }, // Example for future addition
+  { code: 'fr', name: 'Français', flag: '🇫🇷' },
 ];
 
 const getFlagDisplay = (code: string) => {
   switch (code) {
     case 'en': 
-      return <span className="text-xl">🇬🇧</span>;
+      return <span className="text-xl" style={{ fontFamily: `'Segoe UI Emoji', 'Apple Color Emoji', sans-serif` }}>🇬🇧</span>;
     case 'es': 
       return <span className="text-xl" style={{ fontFamily: `'Segoe UI Emoji', 'Apple Color Emoji', sans-serif` }}>
   🇪🇸
 </span>;
+    case 'fr':
+      return <span className="text-xl" style={{ fontFamily: `'Segoe UI Emoji', 'Apple Color Emoji', sans-serif` }}>🇫🇷</span>;
     default: 
-      return <span className="text-xl">🌐</span>;
+      return <span className="text-xl" style={{ fontFamily: `'Segoe UI Emoji', 'Apple Color Emoji', sans-serif` }}>🌐</span>;
   }
 };
 


### PR DESCRIPTION
Updated the language selector to display emoji flags (🇪🇸, 🇬🇧, 🇫🇷) instead of language codes.

- Applied fallback font styles ('Segoe UI Emoji', 'Apple Color Emoji') to ensure consistent emoji rendering across platforms.
- Added French to the list of selectable languages.
- Ensured `text-xl` styling is applied to the flag emojis.